### PR TITLE
Fixes issue with AppCode 2018.3 EAP using improved api for loading run configurations

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.insightfulminds.appcode.XcodeSchemeSelector</id>
   <name>Xcode Scheme Selector</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <vendor email="michael@insightfulminds.com" url="http://www.insightfulminds.com">Insightful Minds Inc.</vendor>
 
   <description><![CDATA[
@@ -31,12 +31,16 @@
             Fixed NullPointerException that happens sometimes while opening a project. Thanks to Paul
             Thorsteinson and Mark Anders for independently reporting this issue.
             </dd>
+            <dt><b>Sep 16, 2018 (Release 1.1.2)</b></dt>
+            <dd>
+            Fixed compatibility issue with AppCode 2018.3 EAP. Thanks to Mark Anders for reporting the issue.
+            </dd>
         </dl>
     ]]>
   </change-notes>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="127"/>
+  <idea-version since-build="183"/>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->

--- a/SchemeSelectorPlugin.iml
+++ b/SchemeSelectorPlugin.iml
@@ -6,7 +6,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="IntelliJ IDEA IU-181.4445.78" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/src/com/insightfulminds/appcode/schemeselector/AppCode.java
+++ b/src/com/insightfulminds/appcode/schemeselector/AppCode.java
@@ -2,6 +2,7 @@ package com.insightfulminds.appcode.schemeselector;
 
 import com.intellij.execution.*;
 import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -75,28 +76,11 @@ public class AppCode {
             return targets;
         }
 
-        for (ConfigurationType configType : runManager.getConfigurationFactories()) {
-
-            Map<String, List<RunnerAndConfigurationSettings>> configStructure = runManager.getStructure(configType);
-            for (List<RunnerAndConfigurationSettings> settingsList : configStructure.values()) {
-                for (RunnerAndConfigurationSettings settings : settingsList) {
-                    try {
-                        // Trick the settings into leaking some private info to help determine what kind of
-                        // target this is
-                        Element root = new Element("Config");
-                        settings.getConfiguration().writeExternal(root);
-
-                        // If the settings contains either of these two attributes, show it in the list
-                        Attribute runTargetProjectName = root.getAttribute("RUN_TARGET_PROJECT_NAME");
-                        Attribute testMode = root.getAttribute("TEST_MODE");
-
-                        if (runTargetProjectName != null || testMode != null) {
-                            targets.add(new Target(this, settings, getConfigurationIcon(settings)));
-                        }
-                    } catch (WriteExternalException e) {
-                        LOG.error(e);
-                    }
-                }
+        for (RunnerAndConfigurationSettings settings : runManager.getAllSettings()) {
+            try {
+                targets.add(new Target(this, settings, getConfigurationIcon(settings)));
+            } catch (WriteExternalException e) {
+                LOG.error(e);
             }
         }
 


### PR DESCRIPTION
Fixes #2, an incompatibility that was introduced in AppCode 2018.3 EAP, Build #OC-183.2407.7.

The IDEA api now throws an exception when a plugin calls the `RunManager.getConfigurationFactories()` method. Per the [comment from Jetbrains](https://youtrack.jetbrains.com/issue/OC-17783#focus=streamItem-27-3068076-0-0), the existing mechanism is no longer available. 

After some experimentation, I have discovered another way to get at the run configurations. I'm not sure if this something that I never noticed before or is a newly available api, but it works and is much cleaner than before.