### PR TITLE
Fix plugin.xml change-notes and version spec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,18 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-//    version = '2021.3.3'
-    localPath = '/Applications/AppCode.app/Contents'
+    // Without this the patchPluginXml will set an explicit until-build
+    // in the plugin.xml which is not desired (want to leave it open)
+    updateSinceUntilBuild = false
+
+    // Set to the latest generic version since the OC- version prefix (for appcode)
+    // is not allowed for some reason
+    version = '2021.3'
+
+    // Use this instead of `version` above when testing the plugin locally
+    // localPath = '/Applications/AppCode 2022.1 EAP.app/Contents'
 }
-patchPluginXml {
-    changeNotes = """
-      Add change notes here.<br>
-      <em>most HTML tags may be used</em>"""
-}
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
By default the Gradle build will overwrite the plugin xml change notes which is not what I want so I just removed `patchPluginXml` from the build script.

More annoyingly, the version specifier from Gradle doesn't do what I want:
* I can't specify an AppCode version (OC- prefix) because that's not supported for some reason, so I just used a generic recent version 2021.3 and tested the new plugin with both the latest stable and EAP versions of AppCode
* When the Gradle build patches the plugin.xml version, it forces a value for `until-build` which is not what I wanted. I found a workaround using `updateSinceUntilBuild = false` to force the build to just use the values I've manually specified in the plugin.xml file. The key point is that I wanted to leave the until version "open" so that the plugin would declare compatibility with all future versions.